### PR TITLE
Replacing -f with -Format

### DIFF
--- a/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
+++ b/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
@@ -210,7 +210,7 @@ if (-not $armLuisAuthoringRegion) {
 }
 
 # Get timestamp
-$timestamp = Get-Date -f MMddyyyyHHmmss
+$timestamp = Get-Date -Format MMddyyyyHHmmss
 
 # Create resource group
 Write-Host "> Creating resource group ..." -NoNewline


### PR DESCRIPTION
Line |
 213 |  $timestamp = Get-Date -f MMddyyyyHHmmss
     |                        ~~
     | Parameter cannot be processed because the parameter name 'f' is ambiguous. Possible
     | matches include: -Format -FromUnixTime.

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
